### PR TITLE
fix: can't connect chromadb with default database and default tenant …

### DIFF
--- a/app/src/services/clients/chromadb.ts
+++ b/app/src/services/clients/chromadb.ts
@@ -235,12 +235,22 @@ export class ChromaDBClient implements VectorDBClient {
       const port = config.port;
       const protocol = config.https ? 'https' : 'http';
       const path = `${protocol}://${host}:${port}`;
+      const tenant = config.tenant;
+      const database = config.database;
 
       this.client = new ChromaClient({
         path,
+        tenant,
+        database,
       });
       this.isCloud = false;
-      log.info('[ChromaDB] Connecting to local ChromaDB', { path, host, port });
+      log.info('[ChromaDB] Connecting to local ChromaDB', {
+        path,
+        host,
+        port,
+        tenant,
+        database,
+      });
     }
 
     // Create default embedding function (will be overridden when we know dimension)


### PR DESCRIPTION
Fix the Bug to connect chromadb with the "default" database and "default" tenant [#11](https://github.com/vectordbz/vectordbz/issues/11)

## Summary

Solved the issue that vectordbz can't connect chromadb with default database and default tenant. 
Related issues:  [#11](https://github.com/vectordbz/vectordbz/issues/11)

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New database integration
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other:

## Testing

- [x] I ran `npm test` and all tests pass
- [x] I ran `npm run lint` and there are no lint errors
- [x] I tested the change manually in the app